### PR TITLE
stable/mongodb: Update to chart version 5.3.0 (app version 4.0.3)

### DIFF
--- a/stable/mongodb/Chart.yaml
+++ b/stable/mongodb/Chart.yaml
@@ -1,7 +1,9 @@
-name: mongodb
-version: 4.0.2
-appVersion: 3.6.6
-description: NoSQL document-oriented database that stores JSON-like documents with dynamic schemas, simplifying the integration of data in content-driven applications.
+appVersion: 4.0.3
+description: NoSQL document-oriented database that stores JSON-like documents with
+  dynamic schemas, simplifying the integration of data in content-driven applications.
+engine: gotpl
+home: https://mongodb.org
+icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:
 - mongodb
 - database
@@ -9,11 +11,10 @@ keywords:
 - cluster
 - replicaset
 - replication
-home: https://mongodb.org
-icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+name: mongodb
 sources:
 - https://github.com/bitnami/bitnami-docker-mongodb
-maintainers:
-- name: Bitnami
-  email: containers@bitnami.com
-engine: gotpl
+version: 5.3.0

--- a/stable/mongodb/README.md
+++ b/stable/mongodb/README.md
@@ -12,6 +12,8 @@ $ helm install stable/mongodb
 
 This chart bootstraps a [MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+
 ## Prerequisites
 
 - Kubernetes 1.4+ with Beta APIs enabled
@@ -43,54 +45,80 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the MongoDB chart and their default values.
 
-|         Parameter                       |             Description                                                                      |                         Default                          |
-|-----------------------------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| `image.registry`                        | MongoDB image registry                                                                       | `docker.io`                                              |
-| `image.repository`                      | MongoDB Image name                                                                           | `bitnami/mongodb`                                        |
-| `image.tag`                             | MongoDB Image tag                                                                            | `{VERSION}`                                              |
-| `image.pullPolicy`                      | Image pull policy                                                                            | `Always`                                                 |
-| `image.pullSecrets`                     | Specify image pull secrets                                                                   | `nil`                                                    |
-| `usePassword`                           | Enable password authentication                                                               | `true`                                                   |
-| `existingSecret`                        | Existing secret with MongoDB credentials                                                     | `nil`                                                    |
-| `mongodbRootPassword`                   | MongoDB admin password                                                                       | `random alhpanumeric string (10)`                        |
-| `mongodbUsername`                       | MongoDB custom user                                                                          | `nil`                                                    |
-| `mongodbPassword`                       | MongoDB custom user password                                                                 | `random alhpanumeric string (10)`                        |
-| `mongodbDatabase`                       | Database to create                                                                           | `nil`                                                    |
-| `mongodbExtraFlags`                     | MongoDB additional command line flags                                                        | []                                                       |
-| `service.type`                          | Kubernetes Service type                                                                      | `ClusterIP`                                              |
-| `service.nodePort`                      | Port to bind to for NodePort service type                                                    | `nil`                                                    |
-| `port`                                  | MongoDB service port                                                                         | `27017`                                                  |
-| `replicaSet.enabled`                    | Switch to enable/disable replica set configuration                                           | `false`                                                  |
-| `replicaSet.name`                       | Name of the replica set                                                                      | `rs0`                                                    |
-| `replicaSet.key`                        | Key used for authentication in the replica set                                               | `nil`                                                    |
-| `replicaSet.replicas.secondary`         | Number of secondary nodes in the replica set                                                 | `1`                                                      |
-| `replicaSet.replicas.arbiter`           | Number of arbiter nodes in the replica set                                                   | `1`                                                      |
-| `replicaSet.pdb.minAvailable.primary`   | PDB for the MongoDB Primary nodes                                                            | `1`                                                      |
-| `replicaSet.pdb.minAvailable.secondary` | PDB for the MongoDB Secondary nodes                                                          | `1`                                                      |
-| `replicaSet.pdb.minAvailable.arbiter`   | PDB for the MongoDB Arbiter nodes                                                            | `1`                                                      |
-| `podAnnotations`                        | Annotations to be added to pods                                                              | {}                                                       |
-| `resources`                             | Pod resources                                                                                | {}                                                       |
-| `nodeSelector`                          | Node labels for pod assignment                                                               | {}                                                       |
-| `affinity`                              | Affinity for pod assignment                                                                  | {}                                                       |
-| `tolerations`                           | Toleration labels for pod assignment                                                         | {}                                                       |
-| `securityContext.enabled`            | Enable security context                                                                      | `true`                            |
-| `securityContext.fsGroup`            | Group ID for the container                                                                   | `1001`                            |
-| `securityContext.runAsUser`          | User ID for the container                                                                    | `1001`              | `persistence.enabled`                   | Use a PVC to persist data                                                                    | `true`                                                   |
-| `persistence.storageClass`              | Storage class of backing PVC                                                                 | `nil` (uses alpha storage class annotation)              |
-| `persistence.accessMode`                | Use volume as ReadOnly or ReadWrite                                                          | `ReadWriteOnce`                                          |
-| `persistence.size`                      | Size of data volume                                                                          | `8Gi`                                                    |
-| `persistence.annotations`               | Persistent Volume annotations                                                                | `{}`                                                     |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                     | `30`                                                     |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                               | `10`                                                     |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                     | `5`                                                      |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                      |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                      |
-| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                    | `5`                                                      |
-| `readinessProbe.periodSeconds`          | How often to perform the probe                                                               | `10`                                                     |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                     | `5`                                                      |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                      |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                      |
-| `configmap`                             | MongoDB configuration file to be used                                                        | `nil`                                                    |
+| Parameter                                          | Description                                                                                  | Default                                                 |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `global.imageRegistry`                             | Global Docker image registry                                                                 | `nil`                                                   |
+| `image.registry`                                   | MongoDB image registry                                                                       | `docker.io`                                             |
+| `image.repository`                                 | MongoDB Image name                                                                           | `bitnami/mongodb`                                       |
+| `image.tag`                                        | MongoDB Image tag                                                                            | `{VERSION}`                                             |
+| `image.pullPolicy`                                 | Image pull policy                                                                            | `Always`                                                |
+| `image.pullSecrets`                                | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`                                      | Specify if debug logs should be enabled                                                      | `false`                                                 |
+| `usePassword`                                      | Enable password authentication                                                               | `true`                                                  |
+| `existingSecret`                                   | Existing secret with MongoDB credentials                                                     | `nil`                                                   |
+| `mongodbRootPassword`                              | MongoDB admin password                                                                       | `random alphanumeric string (10)`                       |
+| `mongodbUsername`                                  | MongoDB custom user                                                                          | `nil`                                                   |
+| `mongodbPassword`                                  | MongoDB custom user password                                                                 | `random alphanumeric string (10)`                       |
+| `mongodbDatabase`                                  | Database to create                                                                           | `nil`                                                   |
+| `mongodbEnableIPv6`                                | Switch to enable/disable IPv6 on MongoDB                                                     | `true`                                                  |
+| `mongodbSystemLogVerbosity`                        | MongoDB systen log verbosity level                                                           | `0`                                                     |
+| `mongodbDisableSystemLog`                          | Whether to disable MongoDB system log or not                                                 | `false`                                                 |
+| `mongodbExtraFlags`                                | MongoDB additional command line flags                                                        | []                                                      |
+| `service.annotations`                              | Kubernetes service annotations                                                               | `{}`                                                    |
+| `service.type`                                     | Kubernetes Service type                                                                      | `ClusterIP`                                             |
+| `service.clusterIP`                                | Static clusterIP or None for headless services                                               | `nil`                                                   |
+| `service.nodePort`                                 | Port to bind to for NodePort service type                                                    | `nil`                                                   |
+| `port`                                             | MongoDB service port                                                                         | `27017`                                                 |
+| `replicaSet.enabled`                               | Switch to enable/disable replica set configuration                                           | `false`                                                 |
+| `replicaSet.name`                                  | Name of the replica set                                                                      | `rs0`                                                   |
+| `replicaSet.useHostnames`                          | Enable DNS hostnames in the replica set config                                               | `true`                                                  |
+| `replicaSet.key`                                   | Key used for authentication in the replica set                                               | `nil`                                                   |
+| `replicaSet.replicas.secondary`                    | Number of secondary nodes in the replica set                                                 | `1`                                                     |
+| `replicaSet.replicas.arbiter`                      | Number of arbiter nodes in the replica set                                                   | `1`                                                     |
+| `replicaSet.pdb.minAvailable.primary`              | PDB for the MongoDB Primary nodes                                                            | `1`                                                     |
+| `replicaSet.pdb.minAvailable.secondary`            | PDB for the MongoDB Secondary nodes                                                          | `1`                                                     |
+| `replicaSet.pdb.minAvailable.arbiter`              | PDB for the MongoDB Arbiter nodes                                                            | `1`                                                     |
+| `podAnnotations`                                   | Annotations to be added to pods                                                              | {}                                                      |
+| `podLabels`                                        | Additional labels for the pod(s).                                                            | {}                                                      |
+| `resources`                                        | Pod resources                                                                                | {}                                                      |
+| `priorityClassName`                                | Pod priority class name                                                                      | ``                                                      |
+| `nodeSelector`                                     | Node labels for pod assignment                                                               | {}                                                      |
+| `affinity`                                         | Affinity for pod assignment                                                                  | {}                                                      |
+| `tolerations`                                      | Toleration labels for pod assignment                                                         | {}                                                      |
+| `securityContext.enabled`                          | Enable security context                                                                      | `true`                                                  |
+| `securityContext.fsGroup`                          | Group ID for the container                                                                   | `1001`                                                  |
+| `securityContext.runAsUser`                        | User ID for the container                                                                    | `1001`                                                  |
+| `persistence.enabled`                              | Use a PVC to persist data                                                                    | `true`                                                  |
+| `persistence.storageClass`                         | Storage class of backing PVC                                                                 | `nil` (uses alpha storage class annotation)             |
+| `persistence.accessMode`                           | Use volume as ReadOnly or ReadWrite                                                          | `ReadWriteOnce`                                         |
+| `persistence.size`                                 | Size of data volume                                                                          | `8Gi`                                                   |
+| `persistence.annotations`                          | Persistent Volume annotations                                                                | `{}`                                                    |
+| `persistence.existingClaim`                        | Name of an existing PVC to use (avoids creating one if this is given)                        | `nil`                                                   |
+| `livenessProbe.initialDelaySeconds`                | Delay before liveness probe is initiated                                                     | `30`                                                    |
+| `livenessProbe.periodSeconds`                      | How often to perform the probe                                                               | `10`                                                    |
+| `livenessProbe.timeoutSeconds`                     | When the probe times out                                                                     | `5`                                                     |
+| `livenessProbe.successThreshold`                   | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                     |
+| `livenessProbe.failureThreshold`                   | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                     |
+| `readinessProbe.initialDelaySeconds`               | Delay before readiness probe is initiated                                                    | `5`                                                     |
+| `readinessProbe.periodSeconds`                     | How often to perform the probe                                                               | `10`                                                    |
+| `readinessProbe.timeoutSeconds`                    | When the probe times out                                                                     | `5`                                                     |
+| `readinessProbe.failureThreshold`                  | Minimum consecutive failures for the probe to be considered failed after having succeeded.   | `6`                                                     |
+| `readinessProbe.successThreshold`                  | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`                                                     |
+| `configmap`                                        | MongoDB configuration file to be used                                                        | `nil`                                                   |
+| `metrics.enabled`                                  | Start a side-car prometheus exporter                                                         | `false`                                                 |
+| `metrics.image.registry`                           | MongoDB exporter image registry                                                              | `docker.io`                                             |
+| `metrics.image.repository`                         | MongoDB exporter image name                                                                  | `forekshub/percona-mongodb-exporter`                    |
+| `metrics.image.tag`                                | MongoDB exporter image tag                                                                   | `latest`                                                |
+| `metrics.image.pullPolicy`                         | Image pull policy                                                                            | `IfNotPresent`                                          |
+| `metrics.image.pullSecrets`                        | Specify docker-registry secret names as an array                                             | `[]` (does not add image pull secrets to deployed pods) |
+| `metrics.podAnnotations`                           | Additional annotations for Metrics exporter pod                                              | {}                                                      |
+| `metrics.resources`                                | Exporter resource requests/limit                                                             | Memory: `256Mi`, CPU: `100m`                            |
+| `metrics.serviceMonitor.enabled`                   | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                 | `false`                                                 |
+| `metrics.serviceMonitor.additionalLabels`          | Used to pass Labels that are required by the Installed Prometheus Operator                   | {}                                                      |
+| `metrics.serviceMonitor.relabellings`              | Specify Metric Relabellings to add to the scrape endpoint                                    | `nil`                                                   |
+| `metrics.serviceMonitor.alerting.rules`            | Define individual alerting rules as required                                                 | {}                                                      |
+| `metrics.serviceMonitor.alerting.additionalLabels` | Used to pass Labels that are required by the Installed Prometheus Operator                   | {}                                                      |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -107,6 +135,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 ```bash
 $ helm install --name my-release -f values.yaml stable/mongodb
 ```
+
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## Replication
@@ -114,8 +143,9 @@ $ helm install --name my-release -f values.yaml stable/mongodb
 You can start the MongoDB chart in replica set mode with the following command:
 
 ```bash
-$ helm install --name my-release stable/mongodb --set replication.enabled=true
+$ helm install --name my-release stable/mongodb --set replicaSet.enabled=true
 ```
+
 ## Production settings and horizontal scaling
 
 The [values-production.yaml](values-production.yaml) file consists a configuration to deploy a scalable and high-available MongoDB deployment for production environments. We recommend that you base your production configuration on this template and adjust the parameters appropriately.
@@ -133,12 +163,29 @@ $ kubectl scale statefulset my-release-mongodb-secondary --replicas=3
 
 Some characteristics of this chart are:
 
-* Each of the participants in the replication has a fixed stateful set so you always know where to find the primary, secondary or arbiter nodes.
-* The number of secondary and arbiter nodes can be scaled out independently.
-* Easy to move an application from using a standalone MongoDB server to use a replica set.
+- Each of the participants in the replication has a fixed stateful set so you always know where to find the primary, secondary or arbiter nodes.
+- The number of secondary and arbiter nodes can be scaled out independently.
+- Easy to move an application from using a standalone MongoDB server to use a replica set.
+
+## Initialize a fresh instance
+
+The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+The allowed extensions are `.sh`, and `.js`.
 
 ## Persistence
 
 The [Bitnami MongoDB](https://github.com/bitnami/bitnami-docker-mongodb) image stores the MongoDB data and configurations at the `/bitnami/mongodb` path of the container.
 
 The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
+
+## Upgrading
+
+### To 5.0.0
+
+When enabling replicaset configuration, backwards compatibility is not guaranteed unless you modify the labels used on the chart's statefulsets.
+Use the workaround below to upgrade from versions previous to 5.0.0. The following example assumes that the release name is `my-release`:
+
+```consoloe
+$ kubectl delete statefulset my-release-mongodb-arbiter my-release-mongodb-primary my-release-mongodb-secondary --cascade=false
+```

--- a/stable/mongodb/files/docker-entrypoint-initdb.d/README.md
+++ b/stable/mongodb/files/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom .sh, or .js file so they are executed during the first boot of the image.
+
+More info in the [bitnami-docker-mongodb](https://github.com/bitnami/bitnami-docker-mongodb#initializing-a-new-instance) repository.

--- a/stable/mongodb/templates/NOTES.txt
+++ b/stable/mongodb/templates/NOTES.txt
@@ -40,7 +40,7 @@ To get the password for "{{ .Values.mongodbUsername }}" run:
 
 To connect to your database run the following command:
 
-    kubectl run {{ template "mongodb.fullname" . }}-client --rm --tty -i --image bitnami/mongodb --command -- mongo admin --host {{ template "mongodb.fullname" . }} {{- if .Values.usePassword }} -u root -p $MONGODB_ROOT_PASSWORD{{- end }}
+    kubectl run --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }}-client --rm --tty -i --restart='Never' --image bitnami/mongodb --command -- mongo admin --host {{ template "mongodb.fullname" . }} {{- if .Values.usePassword }} --authenticationDatabase admin -u root -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 To connect to your database from outside the cluster execute the following commands:
 
@@ -48,20 +48,19 @@ To connect to your database from outside the cluster execute the following comma
 
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mongodb.fullname" . }})
-    mongo --host $NODE_IP --port $NODE_PORT {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
+    mongo --host $NODE_IP --port $NODE_PORT {{- if .Values.usePassword }} --authenticationDatabase admin -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "mongodb.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mongodb.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    mongo --host $SERVICE_IP --port {{ .Values.service.nodePort }} {{- if .Values.usePassword }} --authenticationDatabase admin -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "mongodb.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 27017:27017 &
-    mongo --host 127.0.0.1 {{- if .Values.usePassword }} -p $MONGODB_ROOT_PASSWORD{{- end }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "mongodb.fullname" . }} 27017:27017 &
+    mongo --host 127.0.0.1 {{- if .Values.usePassword }} --authenticationDatabase admin -p $MONGODB_ROOT_PASSWORD{{- end }}
 
 {{- end }}

--- a/stable/mongodb/templates/_helpers.tpl
+++ b/stable/mongodb/templates/_helpers.tpl
@@ -54,11 +54,35 @@ Create the name for the key secret.
 {{- end -}}
 
 {{/*
-Return the proper image name
+Return the proper MongoDB image name
 */}}
 {{- define "mongodb.image" -}}
-{{- $registryName :=  .Values.image.registry -}}
+{{- $registryName := .Values.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the metrics image)
+*/}}
+{{- define "metrics.image" -}}
+{{- $registryName :=  .Values.metrics.image.registry -}}
+{{- $repositoryName := .Values.metrics.image.repository -}}
+{{- $tag := .Values.metrics.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
+

--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -5,24 +5,52 @@ metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
     app: {{ template "mongodb.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "mongodb.name" . }}
+      release: "{{ .Release.Name }}"
   template:
     metadata:
       labels:
         app: {{ template "mongodb.name" . }}
         release: "{{ .Release.Name }}"
+        chart: {{ template "mongodb.chart" . }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+{{- end }}
+      {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end -}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -30,43 +58,55 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
-      initContainers:
-      - name: init-{{ template "mongodb.fullname" . }}
-        image: "{{ template "mongodb.image" . }}"
-        command: ["sh", "-c", "chown 1001 /bitnami/mongodb"]
-        securityContext:
-          fsGroup: 0
-          runAsUser: 0
-        volumeMounts:
-        - name: data
-          mountPath: /bitnami/mongodb
-      {{- end }}
       containers:
       - name: {{ template "mongodb.fullname" . }}
         image: {{ template "mongodb.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- if .Values.image.debug}}
+        - name: NAMI_DEBUG
+          value: "1"
+        {{- end }}
         {{- if .Values.usePassword }}
         - name: MONGODB_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mongodb.fullname" . }}
+              name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
               key: mongodb-root-password
         {{- end }}
+        {{- if .Values.mongodbUsername }}
         - name: MONGODB_USERNAME
-          value: {{ default "" .Values.mongodbUsername | quote }}
+          value: {{ .Values.mongodbUsername | quote }}
+        {{- end }}
         {{- if and .Values.mongodbUsername .Values.mongodbDatabase }}
         - name: MONGODB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "mongodb.fullname" . }}
+              name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
               key: mongodb-password
         {{- end }}
+        - name: MONGODB_SYSTEM_LOG_VERBOSITY
+          value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+        - name: MONGODB_DISABLE_SYSTEM_LOG
+          {{- if .Values.mongodbDisableSystemLog }}
+          value: "yes"
+          {{- else }}
+          value: "no"
+          {{- end }}
+        {{- if .Values.mongodbDatabase }}
         - name: MONGODB_DATABASE
-          value: {{ default "" .Values.mongodbDatabase | quote }}
+          value: {{ .Values.mongodbDatabase | quote }}
+        {{- end }}
+        - name: MONGODB_ENABLE_IPV6
+        {{- if .Values.mongodbEnableIPv6 }}
+          value: "yes"
+        {{- else }}
+          value: "no"
+        {{- end }}
+        {{- if .Values.mongodbExtraFlags }}
         - name: MONGODB_EXTRA_FLAGS
-          value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+          value: {{ .Values.mongodbExtraFlags | join " " }}
+        {{- end }}
         ports:
         - name: mongodb
           containerPort: 27017
@@ -99,6 +139,10 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /bitnami/mongodb
+        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        - name: custom-init-scripts
+          mountPath: /docker-entrypoint-initdb.d
+        {{- end }}
         {{- if .Values.configmap }}
         - name: config
           mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
@@ -106,7 +150,45 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: {{ template "metrics.image" . }}
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+        env:
+        {{- if .Values.usePassword }}
+        - name: MONGODB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
+              key: mongodb-root-password
+        command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://root:${MONGODB_ROOT_PASSWORD}@localhost:{{ .Values.service.port }}/admin' ]
+        {{- else }}
+        command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://localhost:{{ .Values.service.port }}' ]
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: 9216
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
       volumes:
+      {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+      - name: custom-init-scripts
+        configMap:
+          name: {{ template "mongodb.fullname" . }}-init-scripts
+      {{- end }}
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/stable/mongodb/templates/headless-svc-rs.yaml
+++ b/stable/mongodb/templates/headless-svc-rs.yaml
@@ -8,12 +8,21 @@ metadata:
     chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
   - name: mongodb
     port: {{ .Values.service.port }}
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9216
+    targetPort: metrics
+{{- end }}
   selector:
     app: {{ template "mongodb.name" . }}
     release: {{ .Release.Name }}

--- a/stable/mongodb/templates/initialization-configmap.yaml
+++ b/stable/mongodb/templates/initialization-configmap.yaml
@@ -1,0 +1,13 @@
+{{ if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "mongodb.fullname" . }}-init-scripts
+  labels:
+    app: {{ template "mongodb.name" . }}
+    chart: {{ template "mongodb.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]").AsConfig | indent 2 }}
+{{ end }}

--- a/stable/mongodb/templates/prometheus-alerting-rule.yaml
+++ b/stable/mongodb/templates/prometheus-alerting-rule.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled .Values.metrics.serviceMonitor.alerting.rules }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "mongodb.fullname" . }}
+  labels:
+    app: {{ template "mongodb.name" . }}
+    chart: {{ template "mongodb.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.metrics.serviceMonitor.alerting.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.alerting.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  groups:
+{{ toYaml .Values.metrics.serviceMonitor.alerting.rules | indent 4 }}
+{{- end }}

--- a/stable/mongodb/templates/prometheus-service-monitor.yaml
+++ b/stable/mongodb/templates/prometheus-service-monitor.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "mongodb.fullname" . }}
+  labels:
+    app: {{ template "mongodb.name" . }}
+    chart: {{ template "mongodb.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    {{- if .Values.metrics.serviceMonitor.relabellings }}
+    metricRelabelings:
+{{ toYaml .Values.metrics.serviceMonitor.relabellings | indent 4 }}
+    {{- end }}
+  jobLabel: {{ template "mongodb.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ template "mongodb.name" . }}
+      chart: {{ template "mongodb.chart" . }}
+      release: "{{ .Release.Name }}"
+      heritage: "{{ .Release.Service }}"
+{{- end }}      

--- a/stable/mongodb/templates/secrets.yaml
+++ b/stable/mongodb/templates/secrets.yaml
@@ -1,11 +1,11 @@
-{{ if or .Values.usePassword .Values.mongodbPassword -}}
+{{ if and .Values.usePassword (not .Values.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
     app: {{ template "mongodb.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 type: Opaque

--- a/stable/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/stable/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -20,17 +20,36 @@ spec:
     metadata:
       labels:
         app: {{ template "mongodb.name" . }}
+        chart: {{ template "mongodb.chart" . }}
         release: {{ .Release.Name }}
         component: arbiter
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end -}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -46,12 +65,32 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
+          - name: MONGODB_SYSTEM_LOG_VERBOSITY
+            value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+          - name: MONGODB_DISABLE_SYSTEM_LOG
+            {{- if .Values.mongodbDisableSystemLog }}
+            value: "yes"
+            {{- else }}
+            value: "no"
+            {{- end }}
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "arbiter"
           - name: MONGODB_PRIMARY_HOST
-            value: {{ template "mongodb.fullname" . }} 
+            value: {{ template "mongodb.fullname" . }}
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+            {{- end }}
             {{- if .Values.usePassword }}
           - name: MONGODB_PRIMARY_ROOT_PASSWORD
             valueFrom:
@@ -64,15 +103,20 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: mongodb
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -81,11 +125,8 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            exec:
-              command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: mongodb
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -98,6 +139,8 @@ spec:
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
           {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
       {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/templates/statefulset-primary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-primary-rs.yaml
@@ -20,17 +20,41 @@ spec:
     metadata:
       labels:
         app: {{ template "mongodb.name" . }}
+        chart: {{ template "mongodb.chart" . }}
         release: {{ .Release.Name }}
         component: primary
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+{{- end }}
+      {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end -}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -46,16 +70,40 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
+          - name: MONGODB_SYSTEM_LOG_VERBOSITY
+            value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+          - name: MONGODB_DISABLE_SYSTEM_LOG
+            {{- if .Values.mongodbDisableSystemLog }}
+            value: "yes"
+            {{- else }}
+            value: "no"
+            {{- end }}
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "primary"
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+            {{- end }}
+          {{- if .Values.mongodbUsername }}
           - name: MONGODB_USERNAME
             value: {{ .Values.mongodbUsername | quote }}
+          {{- end }}
+          {{- if .Values.mongodbDatabase }}
           - name: MONGODB_DATABASE
             value: {{ .Values.mongodbDatabase | quote }}
+          {{- end }}
             {{- if .Values.usePassword }}
-            {{- if .Values.mongodbPassword }}
+            {{- if or .Values.mongodbPassword .Values.existingSecret }}
           - name: MONGODB_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -73,8 +121,16 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -104,17 +160,61 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /bitnami/mongodb
-          {{- if .Values.configmap }}
+            {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
+            {{- if .Values.configmap }}
             - name: config
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          env:
+          {{- if .Values.usePassword }}
+          - name: MONGODB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
+                key: mongodb-root-password
+          command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://root:${MONGODB_ROOT_PASSWORD}@localhost:{{ .Values.service.port }}/admin' ]
+          {{- else }}
+          command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://localhost:{{ .Values.service.port }}' ]
           {{- end }}
+          ports:
+          - name: metrics
+            containerPort: 9216
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.metrics.resources | indent 12 }}
+{{- end }}
       volumes:
-      {{- if .Values.configmap }}
+        {{- if  (.Files.Glob "files/docker-entrypoint-initdb.d/*[sh|js]") }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "mongodb.fullname" . }}-init-scripts
+        {{- end }}
+        {{- if .Values.configmap }}
         - name: config
           configMap:
             name: {{ template "mongodb.fullname" . }}
-      {{- end }}
+        {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/stable/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/stable/mongodb/templates/statefulset-secondary-rs.yaml
@@ -21,17 +21,41 @@ spec:
     metadata:
       labels:
         app: {{ template "mongodb.name" . }}
+        chart: {{ template "mongodb.chart" . }}
         release: {{ .Release.Name }}
         component: secondary
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+      {{- if or .Values.podAnnotations .Values.metrics.enabled }}
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.podAnnotations | indent 8 }}
+{{- end }}
+      {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end -}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -47,12 +71,32 @@ spec:
           - containerPort: {{ .Values.service.port }}
             name: mongodb
           env:
+          {{- if .Values.image.debug}}
+          - name: NAMI_DEBUG
+            value: "1"
+          {{- end }}
+          - name: MONGODB_SYSTEM_LOG_VERBOSITY
+            value: {{ .Values.mongodbSystemLogVerbosity | quote }}
+          - name: MONGODB_DISABLE_SYSTEM_LOG
+            {{- if .Values.mongodbDisableSystemLog }}
+            value: "yes"
+            {{- else }}
+            value: "no"
+            {{- end }}
+          - name: MONGODB_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: MONGODB_REPLICA_SET_MODE
             value: "secondary"
           - name: MONGODB_PRIMARY_HOST
-            value: {{ template "mongodb.fullname" . }} 
+            value: {{ template "mongodb.fullname" . }}
           - name: MONGODB_REPLICA_SET_NAME
             value: {{ .Values.replicaSet.name | quote }}
+            {{- if .Values.replicaSet.useHostnames }}
+          - name: MONGODB_ADVERTISED_HOSTNAME
+            value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+            {{- end }}
             {{- if .Values.usePassword }}
           - name: MONGODB_PRIMARY_ROOT_PASSWORD
             valueFrom:
@@ -65,8 +109,16 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
                 key: mongodb-replica-set-key
             {{- end }}
+          - name: MONGODB_ENABLE_IPV6
+          {{- if .Values.mongodbEnableIPv6 }}
+            value: "yes"
+          {{- else }}
+            value: "no"
+          {{- end }}
+          {{- if .Values.mongodbExtraFlags }}
           - name: MONGODB_EXTRA_FLAGS
-            value: {{ default "" .Values.mongodbExtraFlags | join " " }}
+            value: {{ .Values.mongodbExtraFlags | join " " }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -101,6 +153,41 @@ spec:
               mountPath: /opt/bitnami/mongodb/conf/mongodb.conf
               subPath: mongodb.conf
             {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          env:
+          {{- if .Values.usePassword }}
+          - name: MONGODB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{- else }}{{ template "mongodb.fullname" . }}{{- end }}
+                key: mongodb-root-password
+          command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://root:${MONGODB_ROOT_PASSWORD}@localhost:{{ .Values.service.port }}/admin' ]
+          {{- else }}
+          command: [ 'sh', '-c', '/bin/mongodb_exporter --mongodb.uri mongodb://localhost:{{ .Values.service.port }}' ]
+          {{- end }}
+          ports:
+          - name: metrics
+            containerPort: 9216
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+{{ toYaml .Values.metrics.resources | indent 12 }}
+{{- end }}
       volumes:
         {{- if .Values.configmap }}
         - name: config

--- a/stable/mongodb/templates/svc-primary-rs.yaml
+++ b/stable/mongodb/templates/svc-primary-rs.yaml
@@ -5,11 +5,18 @@ metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
     app: {{ template "mongodb.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
+   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+   clusterIP: {{ .Values.service.clusterIP }}
+   {{- end }}
   ports:
   - name: mongodb
     port: 27017

--- a/stable/mongodb/templates/svc-standalone.yaml
+++ b/stable/mongodb/templates/svc-standalone.yaml
@@ -5,17 +5,29 @@ metadata:
   name: {{ template "mongodb.fullname" . }}
   labels:
     app: {{ template "mongodb.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
   - name: mongodb
     port: 27017
     targetPort: mongodb
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: 9216
+    targetPort: metrics
 {{- end }}
   selector:
     app: {{ template "mongodb.name" . }}

--- a/stable/mongodb/values-production.yaml
+++ b/stable/mongodb/values-production.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 image:
   ## Bitnami MongoDB registry
   ##
@@ -8,7 +14,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 3.6.6-debian-9
+  tag: 4.0.3
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -20,6 +26,11 @@ image:
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
+
+  ## Set to true if you would like to see extra information on logs
+  ## It turns NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-nami-debugging
+  debug: false
 
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
@@ -39,6 +50,17 @@ usePassword: true
 # mongodbPassword: password
 # mongodbDatabase: database
 
+## Whether enable/disable IPv6 on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+##
+mongodbEnableIPv6: true
+
+## MongoDB System Log configuration
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
+##
+mongodbSystemLogVerbosity: 0
+mongodbDisableSystemLog: false
+
 ## MongoDB additional command line flags
 ##
 ## Can be used to specify command line flags, for example:
@@ -55,9 +77,14 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
+## Kubernetes Cluster Domain
+clusterDomain: cluster.local
+
 ## Kubernetes service type
 service:
+  annotations: {}
   type: ClusterIP
+  # clusterIP: None
   port: 27017
 
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -66,9 +93,14 @@ service:
   # nodePort:
 
 
+## Setting up replication
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+#
 replicaSet:
   ## Whether to create a MongoDB replica set for high availability or not
   enabled: true
+  useHostnames: true
+
   ## Name of the replica set
   ##
   name: rs0
@@ -76,7 +108,7 @@ replicaSet:
   ## Key used for replica set authentication
   ##
   # key: key
-  
+
   ## Number of replicas per each node type
   ##
   replicas:
@@ -93,6 +125,9 @@ replicaSet:
 # Annotations to be added to MongoDB pods
 podAnnotations: {}
 
+# Additional pod labels to apply
+podLabels: {}
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -103,6 +138,10 @@ resources: {}
 # requests:
 #   cpu: 100m
 #   memory: 256Mi
+
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
 
 ## Node selector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -191,3 +230,54 @@ configmap:
 #  security:
 #    authorization: enabled
 #    keyFile: /opt/bitnami/mongodb/conf/keyfile
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: true
+
+  image:
+    registry: docker.io
+    repository: forekshub/percona-mongodb-exporter
+    tag: latest
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+
+  ## Metrics exporter pod Annotation
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9216"
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    enabled: false
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    additionalLabels: {}
+
+    ## Specify Metric Relabellings to add to the scrape endpoint
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    # relabellings:
+
+    alerting:
+      ## Define individual alerting rules as required
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
+      ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+      rules: {}
+
+      ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+      additionalLabels: {}

--- a/stable/mongodb/values.yaml
+++ b/stable/mongodb/values.yaml
@@ -1,3 +1,9 @@
+## Global Docker image registry
+## Please, note that this will override the image registry for all the images, including dependencies, configured to use the global value
+##
+# global:
+#   imageRegistry:
+
 image:
   ## Bitnami MongoDB registry
   ##
@@ -8,7 +14,7 @@ image:
   ## Bitnami MongoDB image tag
   ## ref: https://hub.docker.com/r/bitnami/mongodb/tags/
   ##
-  tag: 3.6.6-debian-9
+  tag: 4.0.3
 
   ## Specify a imagePullPolicy
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -20,6 +26,11 @@ image:
   ##
   # pullSecrets:
   #   - myRegistrKeySecretName
+
+  ## Set to true if you would like to see extra information on logs
+  ## It turns NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-nami-debugging
+  debug: false
 
 ## Enable authentication
 ## ref: https://docs.mongodb.com/manual/tutorial/enable-authentication/
@@ -39,6 +50,18 @@ usePassword: true
 # mongodbPassword: password
 # mongodbDatabase: database
 
+
+## Whether enable/disable IPv6 on MongoDB
+## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+##
+mongodbEnableIPv6: true
+
+## MongoDB System Log configuration
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
+##
+mongodbSystemLogVerbosity: 0
+mongodbDisableSystemLog: false
+
 ## MongoDB additional command line flags
 ##
 ## Can be used to specify command line flags, for example:
@@ -55,9 +78,14 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
+## Kubernetes Cluster Domain
+clusterDomain: cluster.local
+
 ## Kubernetes service type
 service:
+  annotations: {}
   type: ClusterIP
+  # clusterIP: None
   port: 27017
 
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
@@ -65,10 +93,14 @@ service:
   ##
   # nodePort:
 
-
+## Setting up replication
+## ref: https://github.com/bitnami/bitnami-docker-mongodb#setting-up-a-replication
+#
 replicaSet:
   ## Whether to create a MongoDB replica set for high availability or not
   enabled: false
+  useHostnames: true
+
   ## Name of the replica set
   ##
   name: rs0
@@ -93,6 +125,9 @@ replicaSet:
 # Annotations to be added to MongoDB pods
 podAnnotations: {}
 
+# Additional pod labels to apply
+podLabels: {}
+
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -103,6 +138,10 @@ resources: {}
 # requests:
 #   cpu: 100m
 #   memory: 256Mi
+
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
 
 ## Node selector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -191,3 +230,54 @@ configmap:
 #  security:
 #    authorization: enabled
 #    #keyFile: /opt/bitnami/mongodb/conf/keyfile
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: forekshub/percona-mongodb-exporter
+    tag: latest
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistrKeySecretName
+
+  ## Metrics exporter resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  # resources: {}
+
+  ## Metrics exporter pod Annotation
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9216"
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    enabled: false
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    additionalLabels: {}
+
+    ## Specify Metric Relabellings to add to the scrape endpoint
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    # relabellings:
+
+    alerting:
+      ## Define individual alerting rules as required
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#rulegroup
+      ##      https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+      rules: {}
+
+      ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Prometheus Rules to work with
+      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+      additionalLabels: {}


### PR DESCRIPTION
This also includes fixes to the bitnami startup script which should let it deal better with interrupted initial migration.

Note that the version of the upstream stable/mongodb chart after this one pulls in the new mongodb license; it is not yet clear if we're okay to use that version.