### PR TITLE
Fix volume permissions for mongodb

### DIFF
--- a/stable/mongodb/templates/deployment-standalone.yaml
+++ b/stable/mongodb/templates/deployment-standalone.yaml
@@ -58,6 +58,18 @@ spec:
         - name: {{ . }}
       {{- end}}
       {{- end }}
+      {{- if .Values.persistence.enabled }}
+      initContainers:
+      - name: init-{{ template "mongodb.fullname" . }}
+        image: "{{ template "mongodb.image" . }}"
+        command: ["sh", "-c", "chown 1001 /bitnami/mongodb"]
+        securityContext:
+          fsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+        - name: data
+          mountPath: /bitnami/mongodb
+      {{- end }}
       containers:
       - name: {{ template "mongodb.fullname" . }}
         image: {{ template "mongodb.image" . }}


### PR DESCRIPTION
Two commits [*] got lost on the update to the newer mongodb chart;
putting them back in again.

[*]
b1b506ad0e9fa4457cee9db9f14d65dd3c9fad0e
f32c426dc47c3e3b5fe7228974cce83cb6cccf2e
